### PR TITLE
Add pam_strerror to lib API

### DIFF
--- a/pam_shim.map
+++ b/pam_shim.map
@@ -8,6 +8,7 @@ LIBPAM_1.0 {
     pam_open_session;
     pam_setcred;
     pam_start;
+    pam_strerror;
 
     /*
     pam_fail_delay;
@@ -16,7 +17,6 @@ LIBPAM_1.0 {
     pam_getenvlist;
     pam_putenv;
     pam_set_item;
-    pam_strerror;
     */
 
   local: *;

--- a/src/lib/lib.c
+++ b/src/lib/lib.c
@@ -186,6 +186,78 @@ static int pam_default_impl(pam_handle_t *pamh, int flags, enum shim_request_typ
     return default_response.data.result.pam_status;
 }
 
+const char *pam_strerror(pam_handle_t *pamh, int errnum)
+{
+    switch (errnum) {
+    case PAM_SUCCESS:
+      return "Success";
+    case PAM_ABORT:
+      return "Critical error - immediate abort";
+    case PAM_OPEN_ERR:
+      return "Failed to load module";
+    case PAM_SYMBOL_ERR:
+      return "Symbol not found";
+    case PAM_SERVICE_ERR:
+      return "Error in service module";
+    case PAM_SYSTEM_ERR:
+      return "System error";
+    case PAM_BUF_ERR:
+      return "Memory buffer error";
+    case PAM_PERM_DENIED:
+      return "Permission denied";
+    case PAM_AUTH_ERR:
+      return "Authentication failure";
+    case PAM_CRED_INSUFFICIENT:
+      return "Insufficient credentials to access authentication data";
+    case PAM_AUTHINFO_UNAVAIL:
+      return "Authentication service cannot retrieve authentication info";
+    case PAM_USER_UNKNOWN:
+      return "User not known to the underlying authentication module";
+    case PAM_MAXTRIES:
+      return "Have exhausted maximum number of retries for service";
+    case PAM_NEW_AUTHTOK_REQD:
+      return "Authentication token is no longer valid; new one required";
+    case PAM_ACCT_EXPIRED:
+      return "User account has expired";
+    case PAM_SESSION_ERR:
+      return "Cannot make/remove an entry for the specified session";
+    case PAM_CRED_UNAVAIL:
+      return "Authentication service cannot retrieve user credentials";
+    case PAM_CRED_EXPIRED:
+      return "User credentials expired";
+    case PAM_CRED_ERR:
+      return "Failure setting user credentials";
+    case PAM_NO_MODULE_DATA:
+      return "No module specific data is present";
+    case PAM_BAD_ITEM:
+      return "Bad item passed to pam_*_item()";
+    case PAM_CONV_ERR:
+      return "Conversation error";
+    case PAM_AUTHTOK_ERR:
+      return "Authentication token manipulation error";
+    case PAM_AUTHTOK_RECOVERY_ERR:
+      return "Authentication information cannot be recovered";
+    case PAM_AUTHTOK_LOCK_BUSY:
+      return "Authentication token lock busy";
+    case PAM_AUTHTOK_DISABLE_AGING:
+      return "Authentication token aging disabled";
+    case PAM_TRY_AGAIN:
+      return "Failed preliminary check by password service";
+    case PAM_IGNORE:
+      return "The return value should be ignored by PAM dispatch";
+    case PAM_MODULE_UNKNOWN:
+      return "Module is unknown";
+    case PAM_AUTHTOK_EXPIRED:
+      return "Authentication token expired";
+    case PAM_CONV_AGAIN:
+      return "Conversation is waiting for event";
+    case PAM_INCOMPLETE:
+      return "Application needs to call libpam again";
+    }
+
+    return "Unknown PAM error";
+}
+
 #define IMPL(fun, req_type) \
 int fun(pam_handle_t *pamh, int flags) { \
     return pam_default_impl(pamh, flags, req_type); \


### PR DESCRIPTION
Had to add `pam_strerror` to get [waylock](https://codeberg.org/ifreund/waylock/src/branch/master/src/pam.zig#L131) working. Errors codes already defined in [_pam_types.h](https://github.com/Cu3PO42/pam_shim/blob/master/include/security/_pam_types.h)

Tried adding call to `pam_strerror` in test but tbh couldn't get `test-with-shim` working with or without this change. I get `pam_start failed (code 4)` in either case, probably an issue with something on my end. Tested by getting it working with waylock on my system. It correctly prints out error message when failing authentication.